### PR TITLE
Allow 'rootElement' to be specified as a selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Space-separated list of events to listen for e.g. `mousedown mouseup mouseout` o
 
 Any kind of valid CSS selector supported by [`matchesSelector`](http://caniuse.com/matchesselector). Some selectors, like `#id` or `tag` will use optimized functions internally that check for straight matches between the ID or tag name of elements.
 
+Null is also accepted and will match the root element set by `root()`.
+
 #### `handler (function)` ####
 
 Function that will handle the specified event on elements matching the given selector. The function will receive two arguments: the native event object and the target element, in that order.

--- a/_tests/lib/delegateTest.js
+++ b/_tests/lib/delegateTest.js
@@ -444,6 +444,22 @@ buster.testCase('Delegate', {
 
 		delegate.off();
 	},
+
+	// Test for issue #5
+	'The root element, via a null selector, is supported': function() {
+		var delegate, spy, element;
+
+		delegate = new Delegate(document.body);
+		spy = this.spy();
+		delegate.on('click', null, spy);
+
+		element = document.body;
+		element.dispatchEvent(setupHelper.getMouseEvent('click'));
+
+		assert.calledOnce(spy);
+
+		delegate.off();
+	},
 	'tearDown': function() {
 		setupHelper.tearDown();
 	}

--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -138,10 +138,6 @@
 			throw new TypeError('Invalid event type: ' + eventType);
 		}
 
-		if (!selector) {
-			throw new TypeError('Invalid selector: ' + selector);
-		}
-
 		// Support a separated list of event types
 		if (eventType.indexOf(SEPARATOR) !== -1) {
 			eventType.split(SEPARATOR).forEach(function(singleEventType) {
@@ -171,8 +167,15 @@
 			listenerMap[eventType] = [];
 		}
 
+		if (!selector) {
+			matcherParam = null;
+
+			// COMPLEX - matchesRoot needs to have access to
+			// this.rootElement, so bind the function to this.
+			matcher = this.matchesRoot.bind(this);
+
 		// Compile a matcher for the given selector
-		if (/^[a-z]+$/i.test(selector)) {
+		} else if (/^[a-z]+$/i.test(selector)) {
 
 			// Lazily check whether tag names are case sensitive (as in XML or XHTML documents).
 			if (Delegate.tagsCaseSensitive === null) {
@@ -385,6 +388,17 @@
 	 */
 	Delegate.prototype.matchesTag = function(tagName, element) {
 		return tagName === element.tagName;
+	};
+
+	/**
+	 * Check whether an element matches the root.
+	 *
+	 * @param {?String} selector In this case this is always passed through as null and not used
+	 * @param {Element} element The element to test with
+	 * @returns boolean
+	 */
+	Delegate.prototype.matchesRoot = function(selector, element) {
+		return this.rootElement === element;
 	};
 
 	/**


### PR DESCRIPTION
As requested by @georgecrawford.
