### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "dom-delegate",
+  "description": "Create and manage a DOM event delegator.",
+  "main": "lib/delegate.js",
+  "ignore": ["test", "GruntFile.js", ".npmignore", ".gitignore", "README.md", "component.json", "package.json"]
+  "license": "MIT"
+}


### PR DESCRIPTION
There's some confusion over the name & git url of the module. components.json points to the old repo url. Both package.json and components.json name this module (and list in bower & npm registries) as dom-delegate, which now doesn't match with the ftdomdelegate name it's listed under in the origami registry or the repo's name.

I suggest the best way to deal with this is to revert to using the ftlabs/dom-delegate url and name universally and updating origami registry accordingly
