### PR TITLE
Changed from using HTMLElement to Element for matches

### DIFF
--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -387,8 +387,8 @@ Delegate.prototype.fire = function(event, target, listener) {
 Delegate.prototype.matches = (function(el) {
   if (!el) return;
   var p = el.prototype;
-  return (p.matchesSelector || p.webkitMatchesSelector || p.mozMatchesSelector || p.msMatchesSelector || p.oMatchesSelector);
-}(HTMLElement));
+  return (p.matches || p.matchesSelector || p.webkitMatchesSelector || p.mozMatchesSelector || p.msMatchesSelector || p.oMatchesSelector);
+}(Element));
 
 /**
  * Check whether an element


### PR DESCRIPTION
Because
a) ie8 doesn't support HTMLElement
b) the spec defines matches on Element.prototype not on HTMLElement.prototype anyway

Also added p.matches as the preferred native method to use. Does it also need vendor prefixed versions here I wonder?
