### PR TITLE
Fix tests for browsers that have defaultPrevented bugs, or don't support it

### DIFF
--- a/test/tests/delegateTest.js
+++ b/test/tests/delegateTest.js
@@ -218,8 +218,15 @@ buster.testCase('Delegate', {
     delegate.on("click", '#delegate-test-clickable', function(event) {
       spyA();
 
+      // event.defaultPrevented appears to have issues in IE so just mock
+      // preventDefault instead.
+      var defaultPrevented;
+      event.preventDefault = function() {
+        defaultPrevented = true;
+      };
+
       setTimeout(function() {
-        assert.equals(event.defaultPrevented, true);
+        assert.equals(defaultPrevented, true);
         done();
       }, 0);
 


### PR DESCRIPTION
Tested in:
- IE 10.0, Windows 8
- Chrome (latest) OSX
- Firefox (latest) OSX

Please don't merge until I've tested more browsers
