### PR TITLE
Support listening to events triggered directly on the window

### DIFF
--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -397,7 +397,16 @@ function matchesTag(tagName, element) {
  */
 function matchesRoot(selector, element) {
   /*jshint validthis:true*/
-  if (this.rootElement === window) return element === document || element === document.body.parentElement;
+  if (this.rootElement === window) {
+    return (
+      // Match the outer document (dispatched from document)
+      element === document ||
+      // The <html> element (dispatched from document.body or document.documentElement)
+      element === document.documentElement ||
+      // Or the window itself (dispatched from window)
+      element === window
+    );
+  }
   return this.rootElement === element;
 }
 

--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -397,7 +397,7 @@ function matchesTag(tagName, element) {
  */
 function matchesRoot(selector, element) {
   /*jshint validthis:true*/
-  if (this.rootElement === window) return element === document;
+  if (this.rootElement === window) return element === document || element === document.body.parentElement;
   return this.rootElement === element;
 }
 

--- a/test/tests/delegateTest.js
+++ b/test/tests/delegateTest.js
@@ -1,6 +1,9 @@
 /*jshint laxbreak:true*/
 
-/*global buster, assert, refute, Delegate*/
+/*global buster, Delegate*/
+
+var assert = buster.referee.assert;
+var refute = buster.referee.refute;
 
 var setupHelper = {};
 
@@ -592,6 +595,63 @@ buster.testCase('Delegate', {
 
     assert.calledOnce(captureSpy);
     assert.calledOnce(bubbleSpy);
+  },
+  'Delegate instances on window catch events when bubbled from the body' : function() {
+    var delegate, spy;
+
+    delegate = new Delegate(window);
+    spy = this.spy();
+
+    delegate.on('click', spy);
+
+    setupHelper.fireMouseEvent(document.body, 'click');
+
+    assert.calledOnce(spy);
+
+    delegate.off();
+  },
+  'Delegate instances on window catch events when bubbled from the document' : function() {
+    var delegate, spy;
+
+    delegate = new Delegate(window);
+    spy = this.spy();
+
+    delegate.on('click', spy);
+
+    setupHelper.fireMouseEvent(document, 'click');
+
+    // assert.calledOnce(spy); // "Invalid Argument" in IE 9
+    assert(spy.callCount === 1); // Workaround for Buster.js IE 9 error
+
+    delegate.off();
+  },
+  'Delegate instances on window catch events when bubbled from the <html> element' : function() {
+    var delegate, spy;
+
+    delegate = new Delegate(window);
+    spy = this.spy();
+
+    delegate.on('click', spy);
+
+    setupHelper.fireMouseEvent(document.documentElement, 'click');
+
+    assert.calledOnce(spy);
+
+    delegate.off();
+  },
+  'Delegate instances on window cause events when dispatched directly on window' : function() {
+    var delegate, spy;
+
+    delegate = new Delegate(window);
+    spy = this.spy();
+
+    delegate.on('click', spy);
+
+    setupHelper.fireMouseEvent(window, 'click');
+
+    assert.calledOnce(spy);
+
+    delegate.off();
   },
 
   'tearDown': function() {


### PR DESCRIPTION
### Changes
- `matchesRoot` has been modified to check if the element is equal to the `window`
- `matchesRoot` has been modified to check if the element is equal to `document.documentElement`
  - This is a more cross-browser compatible way of implementing the check added by @matthew-andrews in 4f0eaa76c0fa14ff39c79daeb5f9dd7fa45e4885. I've left the previous commit intact for history's sake.
- `assert`/`refute` are explicitly declared now
  - Existing tests were not passing due to both functions being `undefined`.
  - This is related to #59, but does not fix it entirely as tests still will not pass in PhantomJS
### Testing

The following tests were added:
- Delegate instances on window catch events when bubbled from the body
- Delegate instances on window catch events when bubbled from the document
- Delegate instances on window catch events when bubbled from the <html> element
- Delegate instances on window cause events when dispatched directly on window

Tests were ran against the following browsers and are passing
- Safari 7.0.6, OS X 10.9.5
- Chrome 38.0.2125.111, OS X 10.9.5
- Firefox 33.0, OS X 10.9.5
- IE 9.0, Windows 7 Enterprise x64
