### PR TITLE
Look for Element in node's global obj if not found

### DIFF
--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -358,6 +358,13 @@ Delegate.prototype.fire = function(event, target, listener) {
   return listener.handler.call(target, event, target);
 };
 
+var _Element;
+try {
+  _Element = Element;
+} catch(err) {
+  _Element = global.Element;
+}
+
 /**
  * Check whether an element
  * matches a generic selector.
@@ -369,7 +376,7 @@ var matches = (function(el) {
   if (!el) return;
   var p = el.prototype;
   return (p.matches || p.matchesSelector || p.webkitMatchesSelector || p.mozMatchesSelector || p.msMatchesSelector || p.oMatchesSelector);
-}(Element));
+}(_Element));
 
 /**
  * Check whether an element


### PR DESCRIPTION
I'd like to test my ftdomdelegate-using client-side code on the server using JSDom or something similar.

When defining the matches function, we look for `Element` on the window. On server-side code, this results in a ReferenceError.

This change allows me to still test my client-side code using JSDom, as long as, as part of my test setup, I make my JSDom document's `Element` property a property of the node `global` object.

Would this be an acceptable addition?