### PR TITLE
Keep package.json on bower install.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "ftdomdelegate",
   "description": "Create and manage a DOM event delegator.",
   "main": "lib/delegate.js",
-  "ignore": [".github", "test", ".npmignore", ".gitignore", "GruntFile.js", "package.json"],
+  "ignore": [".github", "test", ".npmignore", ".gitignore", "GruntFile.js"],
   "license": "MIT"
 }


### PR DESCRIPTION
When running Jest tests, Scout Asia rely on a component's
`package.json` to resolve Origami components which were installed via Bower.

In [v3](https://github.com/Financial-Times/ftdomdelegate/pull/93) `package.json` was added to Bower's ignore property, which
means their tests now fail. They required v3 without taking action
because it's included in other components such as `o-tooltip` using a
range https://github.com/Financial-Times/o-tooltip/pull/71. We use
a range as the interface of v3 is the same as v2 -- we just removed
the `dom-delegate` alias. 

