### PR TITLE
Fix SVG issues in IE

### DIFF
--- a/lib/delegate.js
+++ b/lib/delegate.js
@@ -1,4 +1,5 @@
 /*jshint browser:true, node:true*/
+/* global HTMLDocument */
 
 'use strict';
 
@@ -277,6 +278,11 @@ Delegate.prototype.handle = function(event) {
     target = target.parentNode;
   }
 
+  // Handle SVG <use> elements in IE
+  if (target.correspondingUseElement) {
+    target = target.correspondingUseElement;
+  }
+
   root = this.rootElement;
 
   phase = event.eventPhase || ( event.target !== event.currentTarget ? 3 : 2 );
@@ -342,7 +348,14 @@ Delegate.prototype.handle = function(event) {
     }
 
     l = listenerList.length;
-    target = target.parentElement;
+
+    // Fall back to parentNode since SVG children have no parentElement in IE
+    target = target.parentElement || target.parentNode;
+
+    // Do not traverse up to document root when using parentNode, though
+    if (target instanceof HTMLDocument) {
+      break;
+    }
   }
 };
 

--- a/test/tests/delegateTest.js
+++ b/test/tests/delegateTest.js
@@ -19,6 +19,7 @@ setupHelper.setUp = function() {
     + '</div>'
     + '<svg viewBox="0 0 120 120" version="1.1" xmlns="http://www.w3.org/2000/svg">'
       + '<circle id="svg-delegate-test-clickable" cx="60" cy="60" r="50"/>'
+      + '<use id="svg-delegate-test-mouseover" href="#svg-delegate-test-clickable" x="100" fill="blue"/>'
     + '</svg>'
   );
 };
@@ -152,6 +153,23 @@ buster.testCase('Delegate', {
 
     assert.calledOnce(spy);
 
+    delegate.off();
+  },
+  'Event delegation is supported for svg' : function() {
+    var delegate, spy, element;
+
+    delegate = new Delegate(document);
+    spy = this.spy();
+    delegate.on('mouseover', 'svg', function (event) {
+      spy();
+      return false;
+    });
+
+    element = document.getElementById('svg-delegate-test-mouseover');
+    setupHelper.fireMouseEvent(element, 'mouseover');
+
+    assert.calledOnce(spy);
+    
     delegate.off();
   },
   'Class name selectors are supported' : function() {


### PR DESCRIPTION
- Triggering an event from a `use` element would throw an error (see corresponding fix in [React]( https://github.com/facebook/react/commit/2fdaba49c72d6c95046b05d0ef80de1e1bef69cc))
- Attempting to trigger an event on an SVG from a child element would not register anything (possibly related to https://github.com/Financial-Times/ftdomdelegate/issues/89)