### PR TITLE
Remove matches iife, so it doesn't run upon require.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ The library has been deployed as part of the [FT Web App](http://app.ft.com/) an
 * Android Browser on Android 2 +
 * PlayBook OS 1 +
 
+You'll need the following polyfill to support IE11:
+ - [Element.prototype.matches](https://polyfill.io/v2/docs/features/#Element_prototype_matches)
+
 For older browsers (IE8) you'll need the following polyfills
 
  - [Event](https://polyfill.io/v2/docs/features/#Event)
  - [Array.prototype.map](https://polyfill.io/v2/docs/features/#Array_prototype_map)
  - [Function.prototype.bind](https://polyfill.io/v2/docs/features/#Function_prototype_bind)
  - [document.querySelector](https://polyfill.io/v2/docs/features/#document_querySelector)
- - [Element.prototype.matches](https://polyfill.io/v2/docs/features/#Element_prototype_matches)
 
 The easiest way is to include the following script tag and let [Polyfill.io](https://Polyfill.io) work its magic
 

--- a/src/js/delegate.js
+++ b/src/js/delegate.js
@@ -174,7 +174,7 @@ Delegate.prototype.on = function (eventType, selector, handler, useCapture) {
 		matcher = matchesId;
 	} else {
 		matcherParam = selector;
-		matcher = matches;
+		matcher = Element.prototype.matches;
 	}
 
 	// Add to the list of listeners
@@ -375,21 +375,6 @@ Delegate.prototype.handle = function (event) {
 Delegate.prototype.fire = function (event, target, listener) {
 	return listener.handler.call(target, event, target);
 };
-
-/**
- * Check whether an element
- * matches a generic selector.
- *
- * @type function()
- * @param {string} selector A CSS selector
- */
-let matches = (function (el) {
-	if (!el) {
-		return;
-	}
-	let p = el.prototype;
-	return (p.matches || p.matchesSelector || p.webkitMatchesSelector || p.mozMatchesSelector || p.msMatchesSelector || p.oMatchesSelector);
-}(Element));
 
 /**
  * Check whether an element


### PR DESCRIPTION
Related to: https://github.com/Financial-Times/ftdomdelegate/pull/87
Similar to: https://github.com/Financial-Times/o-grid/pull/171

I'll update the README to reflect our current browser support later; 
but don't intend on making code changes explicitly to remove browser support. 
We can revisit ftdomdelegate after the major cascade if we'd like to simplify (or 
deprecate?) it.