### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: npm config set prefix "$HOME/.local"
-      - run: npm i -g origami-build-tools@^7
+      - run: npm i -g origami-build-tools@^9
       - run: $HOME/.local/bin/obt install
       - run: $HOME/.local/bin/obt demo --demo-filter pa11y --suppress-errors
       - run: $HOME/.local/bin/obt verify

--- a/test/delegate.test.js
+++ b/test/delegate.test.js
@@ -1,7 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim sinon */
 import Delegate from '../main';
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 
 const setupHelper = {};
 

--- a/test/scroll.test.js
+++ b/test/scroll.test.js
@@ -1,7 +1,6 @@
-/* eslint-env mocha, sinon, proclaim */
+/* eslint-env mocha */
+/* global proclaim sinon */
 import Delegate from '../main';
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 
 describe("Delegate", () => {
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.