### PR TITLE
 Make automated publishing from GitHub Action work

### DIFF
--- a/.github/workflows/automatic-tag-and-release.yml
+++ b/.github/workflows/automatic-tag-and-release.yml
@@ -17,4 +17,4 @@ jobs:
         name: Create new version/tag
         if: github.event.pull_request.merged  # Only run on merged pull-requests
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}


### PR DESCRIPTION
use a token which is not the default token so that other actions can be triggered based on this action