### PR TITLE
Brings the release  workflow inline with other components.

### DIFF
--- a/.github/workflows/release-origami-component.yml
+++ b/.github/workflows/release-origami-component.yml
@@ -12,6 +12,16 @@ jobs:
         node-version: '12.x'
         registry-url: 'https://registry.npmjs.org'
     - run: npm install --only=dev
+    - name: Repository name
+      id: repo_name
+      run: echo ::set-output name=REPO_NAME::$(echo $GITHUB_REPOSITORY | cut -d / -f 2)
+    - name: Get the version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
     - run: npx origami-ci release
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NPM_CONFIG_USERCONFIG: ~/.npmrc
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        ORIGAMI_CI_NAME: ${{ steps.repo_name.outputs.REPO_NAME }}
+        ORIGAMI_CI_VERSION: ${{ steps.version.outputs.VERSION }}
+        GITHUB_TOKEN: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}


### PR DESCRIPTION
The npm release is currently failing:
https://github.com/Financial-Times/ftdomdelegate/runs/959144500?check_suite_focus=true