### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/test/delegate.test.js
+++ b/test/delegate.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import Delegate from '../main';
+import Delegate from '../main.js';
 
 const setupHelper = {};
 

--- a/test/scroll.test.js
+++ b/test/scroll.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import Delegate from '../main';
+import Delegate from '../main.js';
 
 describe("Delegate", () => {
 


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing